### PR TITLE
Fix generateTributaryMaps

### DIFF
--- a/src/tools/utils/__test__/countertop.unit.test.js
+++ b/src/tools/utils/__test__/countertop.unit.test.js
@@ -298,5 +298,22 @@ describe('countertop', () => {
 			expect(result.length).toBe(1)
 			expect(normalizeTributaryMaps(result, stations)).toMatchSnapshot()
 		})
+
+		it('should return an empty array if a populated output map does not have outputs for all inputs', () => {
+			const stationA = new CountertopStation(generateMockAppliance({
+				inputTypes: [],
+				outputTypes: ['foo'],
+			}))
+			const stationB = new CountertopStation(generateMockAppliance({
+				inputTypes: ['bar'],
+				outputTypes: ['baz'],
+			}))
+			const streamA = new CountertopStream(stationA)
+			const streamMap = new Map([
+				['foo', [streamA]],
+			])
+			const result = generateTributaryMaps(stationB, streamMap)
+			expect(result).toEqual([])
+		})
 	})
 })

--- a/src/tools/utils/countertop.js
+++ b/src/tools/utils/countertop.js
@@ -141,7 +141,7 @@ export const generateTributaryMaps = (station, streamOutputMap) => {
 	const inputTypes = station.getInputTypes()
 	return inputTypes.reduce(
 		(accumulator, type) => accumulator.flatMap(
-			(tributarySet) => streamOutputMap.get(type)
+			(tributarySet) => (streamOutputMap.get(type) || [])
 				.filter((stream) => stream.getSource() === tributarySet.get('source'))
 				.map((stream) => tributarySet.set(type, stream)),
 		),


### PR DESCRIPTION
There was 

Issue #95

## Description
This PR fixes an issue where generateTributaryMaps would sometimes throw an error if a populated streamOutputMap did not contain a valid output for every input of a given station.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #95
