### PR TITLE
Make kafka configurable via API

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,0 @@
-# The amount of detail you want to appear in logs
-# We use the default npm log levels as described in https://github.com/winstonjs/winston#logging-levels
-LOG_LEVEL=info
-
-# A comma-delimited list of Kafka brokers
-KAFKA_BROKERS=localhost:9092

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 services:
   - docker
 
-before_script:
-  - npm run kafka:start
+before_install:
+  - docker-compose -f services/kafka/docker-compose.yml up -d
 
 script:
   - npm run lint

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,21 +17,17 @@ Follow these steps to set up the project on a new development machine. Instructi
     yarn install
     ```
 
-2. Set up an instance of Kafka
-
-3. Create your local configuration
-
-    ```shell
-    cp .env.template .env
-    vi .env
-    ```
 
 ### Setting up Kafka
 
-This project uses Kafka. You can set up Kafka using whatever method you prefer, just configure the TV Kitchen to use your instance by populating `KAFKA_BROKERS` in `.env`.
+This project uses Kafka. You can set up Kafka using whatever method you prefer, just configure the TV Kitchen to use your instance by populating `kafkaSettings` when constructing a `Countertop` instance.
 
-The repository provides a Docker-based Kafka configuration as well for convenience.
 
-Running our provided setup requires [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/).  Once Docker is installed you can activate Kafka by typing `yarn kafka:start`.  You can also stop Kafka by typing `yarn kafka:stop`.
-
-NOTE: If you are using the Dockerized Kafka, populate `KAFKA_BROKERS` in `.env` with the value `localhost:9092`.
+```
+import Countertop from `@tvkitchen/countertop`
+const countertop = new Countertop({
+	kafkaSettings: {
+		brokers: ['127.0.0.1:9092']
+	}
+})
+```

--- a/package.json
+++ b/package.json
@@ -2,12 +2,9 @@
   "name": "@tvkitchen/countertop",
   "version": "0.1.0",
   "description": "The entry point for developers who want to set up a TV Kitchen.",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "build": "yarn run babel src -d lib",
-    "kafka": "yarn kafka:start",
-    "kafka:start": "./services/kafka/start.sh",
-    "kafka:stop": "./services/kafka/stop.sh",
     "lint": "./node_modules/.bin/eslint 'src/**/*.js'",
     "sandbox": "babel-node -- src/scripts/_sandbox",
     "start": "yarn babel-node src/index.js",

--- a/services/kafka/start.sh
+++ b/services/kafka/start.sh
@@ -1,2 +1,0 @@
-BASEDIR=$(dirname $0)
-docker-compose -f ${BASEDIR}/docker-compose.yml up -d

--- a/services/kafka/stop.sh
+++ b/services/kafka/stop.sh
@@ -1,2 +1,0 @@
-BASEDIR=$(dirname $0)
-docker-compose -f ${BASEDIR}/docker-compose.yml stop

--- a/src/classes/Countertop.js
+++ b/src/classes/Countertop.js
@@ -1,3 +1,4 @@
+import { Kafka } from 'kafkajs'
 import { countertopStates } from '../constants'
 import { consoleLogger } from '../tools/loggers'
 import CountertopStation from './CountertopStation'
@@ -13,18 +14,23 @@ import CountertopTopology from './CountertopTopology'
 class Countertop {
 	logger = null
 
+	kafka = null
+
 	stations = []
 
 	state = ''
 
 	/**
-	 * @param  {Logger} options.logger A logger with methods for all TV Kitchen logLevels.
+	 * @param  {Logger} options.logger        A logger with methods for all TV Kitchen logLevels.
+	 * @param  {Object} options.kafkaSettings Kafka settings as defined in the kafkajs library.
 	 */
 	constructor({
 		logger = consoleLogger,
+		kafkaSettings = {},
 	} = {}) {
 		this.logger = logger
 		this.setState(countertopStates.STOPPED)
+		this.kafka = new Kafka(kafkaSettings)
 	}
 
 	/**
@@ -46,6 +52,7 @@ class Countertop {
 			applianceSettings,
 			{
 				logger: this.logger,
+				kafka: this.kafka,
 			},
 		)
 		this.stations.push(station)

--- a/src/classes/CountertopStation.js
+++ b/src/classes/CountertopStation.js
@@ -6,6 +6,8 @@ import CountertopWorker from './CountertopWorker'
 class CountertopStation {
 	logger = null
 
+	kafka = null
+
 	id = null
 
 	Appliance = null
@@ -28,14 +30,16 @@ class CountertopStation {
 		applianceSettings = {},
 		{
 			logger = consoleLogger,
+			kafka,
 		} = {},
 	) {
-		if (typeof Appliance === 'undefined') {
+		if (Appliance === undefined) {
 			throw new Error('CountertopStation requires an Appliance.')
 		}
 		this.Appliance = Appliance
 		this.applianceSettings = applianceSettings
 		this.logger = logger
+		this.kafka = kafka
 		this.id = `${Appliance.name}::${uuid()}`
 		this.setState(countertopStates.STOPPED)
 	}
@@ -55,7 +59,11 @@ class CountertopStation {
 		this.workers = stationStreams.map((stream) => new CountertopWorker(
 			this.Appliance,
 			this.applianceSettings,
-			{ stream },
+			{
+				stream,
+				logger: this.logger,
+				kafka: this.kafka,
+			},
 		))
 		return this.workers
 	}

--- a/src/classes/__test__/Countertop.unit.test.js
+++ b/src/classes/__test__/Countertop.unit.test.js
@@ -6,6 +6,8 @@ import {
 	generateMockAppliance,
 } from '../../tools/utils/jest'
 
+jest.mock('kafkajs')
+
 describe('Countertop #unit', () => {
 	describe('constructor', () => {
 		it('Should accept a custom logger', () => {

--- a/src/classes/__test__/CountertopStation.unit.test.js
+++ b/src/classes/__test__/CountertopStation.unit.test.js
@@ -1,8 +1,11 @@
+import { Kafka } from 'kafkajs'
 import CountertopStation from '../CountertopStation'
 import CountertopTopology from '../CountertopTopology'
 import {
 	generateMockAppliance,
 } from '../../tools/utils/jest'
+
+jest.mock('kafkajs')
 
 describe('CountertopStation #unit', () => {
 	describe('constructor', () => {
@@ -43,7 +46,11 @@ describe('CountertopStation #unit', () => {
 				inputTypes: [],
 				outputTypes: ['bar'],
 			})
-			const countertopStation = new CountertopStation(appliance)
+			const countertopStation = new CountertopStation(
+				appliance,
+				{},
+				{ kafka: new Kafka() },
+			)
 			const topology = new CountertopTopology([countertopStation])
 			const workers = await countertopStation.invokeTopology(topology)
 			expect(workers.length).toEqual(1)

--- a/src/classes/__test__/CountertopWorker.unit.test.js
+++ b/src/classes/__test__/CountertopWorker.unit.test.js
@@ -1,9 +1,12 @@
+import { Kafka } from 'kafkajs'
 import CountertopWorker from '../CountertopWorker'
 import CountertopStation from '../CountertopStation'
 import CountertopStream from '../CountertopStream'
 import {
 	generateMockAppliance,
 } from '../../tools/utils/jest'
+
+jest.mock('kafkajs')
 
 describe('CountertopWorker #unit', () => {
 	describe('constructor', () => {
@@ -34,7 +37,10 @@ describe('CountertopWorker #unit', () => {
 			const worker = new CountertopWorker(
 				Appliance,
 				null,
-				{ stream },
+				{
+					stream,
+					kafka: new Kafka(),
+				},
 			)
 			expect(await worker.start()).toBe(false)
 		})

--- a/src/tests/topology.int.test.js
+++ b/src/tests/topology.int.test.js
@@ -5,6 +5,8 @@ import {
 	normalizeStreams,
 } from '../tools/utils/jest'
 
+jest.mock('kafkajs')
+
 describe('Countertop #integration', () => {
 	describe('updateTopology', () => {
 		it('Should generate correct simple linear topologies', async () => {

--- a/src/tools/kafka/index.js
+++ b/src/tools/kafka/index.js
@@ -1,9 +1,0 @@
-import { Kafka } from 'kafkajs'
-import config from '../../config'
-
-const kafka = new Kafka({
-	clientId: 'tv-kitchen',
-	brokers: [config.KAFKA_BROKERS],
-})
-
-export default kafka


### PR DESCRIPTION
## Description
This PR adds the ability for a developer to specify kafka configuration settings when creating a Countertop.  In turn, it removes the (very simple) `kafka` tool we created and the ability to configure kafka via environment variables.

Kafka injection is now a part of the core countertop components (countertop => stations => workers)

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
Resolves #99 