### PR TITLE
Enable subscriptions

### DIFF
--- a/src/classes/Countertop.js
+++ b/src/classes/Countertop.js
@@ -120,6 +120,20 @@ class Countertop {
 	 * This is an internal method.
 	 */
 	setState = (state) => { this.state = state }
+
+	/**
+	 * Registers a listener to the Countertop for a given event type.
+	 *
+	 * Event types are defined in @tvkitchen/base-constants
+	 *
+	 * @param  {String} eventType  The type of event being listened to.
+	 * @param  {Function} listener The listener to be registered for that event.
+	 * @return {Countertop}        The countertop instance (to enable chaining).
+	 */
+	on = (eventType, listener) => {
+		this.stations.forEach((station) => station.on(eventType, listener))
+		return this
+	}
 }
 
 export default Countertop

--- a/src/classes/CountertopStation.js
+++ b/src/classes/CountertopStation.js
@@ -115,18 +115,32 @@ class CountertopStation {
 	getOutputTypes = () => this.Appliance.getOutputTypes()
 
 	/**
-	 * Get the current state of the CountertopWorker.
+	 * Get the current state of the CountertopStation.
 	 *
-	 * @return {String} The state of the CountertopWorker.
+	 * @return {String} The state of the CountertopStation.
 	 */
 	getState = () => this.state
 
 	/**
-	 * Set the current state of the Countertop.
+	 * Set the current state of the CountertopStation.
 	 *
 	 * This is an internal method.
 	 */
 	setState = (state) => { this.state = state }
+
+	/**
+	 * Registers a listener to the CountertopStation for a given event type.
+	 *
+	 * Event types are defined in @tvkitchen/base-constants
+	 *
+	 * @param  {String} eventType  The type of event being listened to.
+	 * @param  {Function} listener The listener to be registered for that event.
+	 * @return {CountertopStation} The CountertopStation instance (to enable chaining).
+	 */
+	on = (eventType, listener) => {
+		this.workers.forEach((worker) => worker.on(eventType, listener))
+		return this
+	}
 }
 
 export default CountertopStation

--- a/src/classes/CountertopWorker.js
+++ b/src/classes/CountertopWorker.js
@@ -131,6 +131,20 @@ class CountertopWorker {
 		await this.admin.disconnect()
 		return true
 	}
+
+	/**
+	 * Registers a listener to the CountertopWorker for a given event type.
+	 *
+	 * Event types are defined in @tvkitchen/base-constants
+	 *
+	 * @param  {String} eventType  The type of event being listened to.
+	 * @param  {Function} listener The listener to be registered for that event.
+	 * @return {CountertopWorker}  The CountertopWorker instance (to enable chaining).
+	 */
+	on = (eventType, listener) => {
+		this.appliance.on(eventType, listener)
+		return this
+	}
 }
 
 export default CountertopWorker


### PR DESCRIPTION
## Description
This PR adds support for the `on` method in Countertop (and the various countertop components). This allows a developer to listen for appliance events (and eventually any kind of countertop event).

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
Resolves #100 
Related to #82 

Relies on PR #102  