### PR TITLE
Use Avro payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://tv.kitchen",
   "dependencies": {
     "@jest/console": "^25.1.0",
-    "@tvkitchen/base-classes": "^1.3.0",
+    "@tvkitchen/base-classes": "1.4.0-alpha.1",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.0",
     "@tvkitchen/base-interfaces": "4.0.0-alpha.2",

--- a/src/classes/CountertopWorker.js
+++ b/src/classes/CountertopWorker.js
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import { IAppliance } from '@tvkitchen/base-interfaces'
-import { Payload } from '@tvkitchen/base-classes'
+import { AvroPayload } from '@tvkitchen/base-classes'
 import { applianceEvents } from '@tvkitchen/base-constants'
 import { consoleLogger } from '../tools/loggers'
 import { getStreamTopic } from '../tools/utils/countertop'
@@ -64,7 +64,7 @@ class CountertopWorker {
 			(payload) => this.producer.send({
 				topic: getStreamTopic(payload.type, this.stream),
 				messages: [{
-					value: Payload.serialize(payload),
+					value: AvroPayload.serialize(payload),
 				}],
 			}),
 		)
@@ -111,7 +111,7 @@ class CountertopWorker {
 		await this.consumer.run({
 			eachMessage: async ({ message }) => {
 				this.logger.debug(`CountertopWorker<${this.stream.id}>.consumer: eachMessage()`)
-				const payload = Payload.deserialize(message.value)
+				const payload = AvroPayload.deserialize(message.value)
 				await this.appliance.ingestPayload(payload)
 			},
 		})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,10 +1128,12 @@
   dependencies:
     type-detect "4.0.8"
 
-"@tvkitchen/base-classes@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.3.0.tgz#0cf56fcd3deed95097a5b9fe6aed3794f15dce53"
-  integrity sha512-cpeOeK9EQ84ty8heXn4lhJn2uLHGGQj0jsBbm2CPv0APSi2WmH6Mzpv7iUvsEzksqbltJ5plyG6YCdfKz/RaoA==
+"@tvkitchen/base-classes@1.4.0-alpha.1":
+  version "1.4.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.4.0-alpha.1.tgz#af55076cb06e24907707e3c5f59133b098f830a8"
+  integrity sha512-Ge0+3lEpKpBP8fXCgP4Prhie/JKj/xa/MYzOQSjF8tQNAzIUtj7dhrHjt5UWniJAk4f0iDqpPS7xNGCPSjNrTw==
+  dependencies:
+    avsc "^5.4.21"
 
 "@tvkitchen/base-constants@^1.1.1", "@tvkitchen/base-constants@^1.2.0":
   version "1.2.0"
@@ -1402,6 +1404,11 @@ atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+avsc@^5.4.21:
+  version "5.4.22"
+  resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.4.22.tgz#5d415338114d60771288eb68df85a06858a49212"
+  integrity sha512-3PuueubBH33oLLhnnwmjZh/+kvcpyyuOlsmvUaNAgvsk/cAZe0Zs8OgYmL7z6sXWyEfV2PjyyxwCeoiJIwYpEg==
 
 aws-sign2@~0.7.0:
   version "0.7.0"


### PR DESCRIPTION
## Description
This PR updates the countertop to use AvroPayload serialization, which is much more efficient than the default serialization of `Payload`

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
- `yarn install`

## Related Issues
Resolves #104 