### PR TITLE
Stop using console.trace

### DIFF
--- a/src/tools/loggers/consoleLogger.js
+++ b/src/tools/loggers/consoleLogger.js
@@ -18,7 +18,7 @@ const log = (level, message) => {
 		case logLevels.debug:
 			return console.debug(structuredMessage)
 		case logLevels.trace:
-			return console.trace(structuredMessage)
+			return console.debug(structuredMessage)
 		default:
 			return console.log(structuredMessage)
 	}


### PR DESCRIPTION
## Description
This PR changes the default logger to use `console.debug` instead of `console.trace` for trace level logging.  It turns out console.trace posts a full stack trace which is not expected behavior of our logger.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Related to #101 
