### PR TITLE
Silent default logger

### DIFF
--- a/src/classes/Countertop.js
+++ b/src/classes/Countertop.js
@@ -1,6 +1,6 @@
 import { Kafka } from 'kafkajs'
 import { countertopStates } from '../constants'
-import { consoleLogger } from '../tools/loggers'
+import { silentLogger } from '../tools/loggers'
 import CountertopStation from './CountertopStation'
 import CountertopTopology from './CountertopTopology'
 
@@ -25,7 +25,7 @@ class Countertop {
 	 * @param  {Object} options.kafkaSettings Kafka settings as defined in the kafkajs library.
 	 */
 	constructor({
-		logger = consoleLogger,
+		logger = silentLogger,
 		kafkaSettings = {},
 	} = {}) {
 		this.logger = logger

--- a/src/classes/CountertopWorker.js
+++ b/src/classes/CountertopWorker.js
@@ -110,7 +110,7 @@ class CountertopWorker {
 		}
 		await this.consumer.run({
 			eachMessage: async ({ message }) => {
-				this.logger.debug(`CountertopWorker<${this.stream.id}>.consumer: eachMessage()`)
+				this.logger.trace(`CountertopWorker<${this.stream.id}>.consumer: eachMessage()`)
 				const payload = AvroPayload.deserialize(message.value)
 				await this.appliance.ingestPayload(payload)
 			},

--- a/src/tools/loggers/__test__/silentLogger.unit.test.js
+++ b/src/tools/loggers/__test__/silentLogger.unit.test.js
@@ -1,0 +1,27 @@
+import silentLogger from '../silentLogger'
+
+describe('silentLogger #unit', () => {
+	describe('default', () => {
+		it('should support the log() method', () => {
+			expect(() => silentLogger.log('customLevel', 'Test message')).not.toThrow()
+		})
+		it('should support the fatal() method', () => {
+			expect(() => silentLogger.fatal('Test message')).not.toThrow()
+		})
+		it('should support the error() method', () => {
+			expect(() => silentLogger.error('Test message')).not.toThrow()
+		})
+		it('should support the warn() method', () => {
+			expect(() => silentLogger.warn('Test message')).not.toThrow()
+		})
+		it('should support the info() method', () => {
+			expect(() => silentLogger.info('Test message')).not.toThrow()
+		})
+		it('should support the debug() method', () => {
+			expect(() => silentLogger.debug('Test message')).not.toThrow()
+		})
+		it('should support the trace() method', () => {
+			expect(() => silentLogger.trace('Test message')).not.toThrow()
+		})
+	})
+})

--- a/src/tools/loggers/index.js
+++ b/src/tools/loggers/index.js
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export { default as consoleLogger } from './consoleLogger'
+export { default as silentLogger } from './silentLogger'

--- a/src/tools/loggers/silentLogger.js
+++ b/src/tools/loggers/silentLogger.js
@@ -1,0 +1,13 @@
+import { logLevels } from '@tvkitchen/base-constants'
+
+const log = () => {}
+
+export default {
+	log,
+	fatal: log.bind(this, logLevels.fatal),
+	error: log.bind(this, logLevels.error),
+	warn: log.bind(this, logLevels.warn),
+	info: log.bind(this, logLevels.info),
+	debug: log.bind(this, logLevels.debug),
+	trace: log.bind(this, logLevels.trace),
+}


### PR DESCRIPTION
## Description
This PR replaces the default logger to be a silent logger.  This means that developers who want logs will have to pass their own logger to the countertop upon creation.

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #101 
