### PR TITLE
Fix message ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Message ordering from CountertopWorkers are now guaranteed.
 
 ## [0.1.0] - 2020-09-09
-
 ### Added
 - Initial implementation of the `countertop` package.
 


### PR DESCRIPTION
## Description
This PR fixes CountertopWorker so that it will not write to Kafka until the previous payload has been processed. 

## Due Diligence Checklist
- [x] Tests
- [x] Documentation
- [x] Consolidated commits
- [x] Relevant labels assigned
- [x] Changelog(s) updated

## Steps to Test
1. `yarn test`

## Deploy Notes
None

## Related Issues
Resolves #110 