### PR TITLE
Add a default Kafka broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Countertop` now has a default value for `kafkaSettings.brokers`.
 ### Changed
 - Removed an old configuration file.
 - Removed unused dependencies.

--- a/src/classes/Countertop.js
+++ b/src/classes/Countertop.js
@@ -22,7 +22,7 @@ class Countertop {
 
 	/**
 	 * @param  {Logger} options.logger        A logger with methods for all TV Kitchen logLevels.
-	 * @param  {Object} options.kafkaSettings Kafka settings as defined in the kafkajs library.
+	 * @param  {Object} options.kafkaSettings Kafka settings as defined in the KafkaJS library.
 	 */
 	constructor({
 		logger = silentLogger,
@@ -30,7 +30,10 @@ class Countertop {
 	} = {}) {
 		this.logger = logger
 		this.setState(countertopStates.STOPPED)
-		this.kafka = new Kafka(kafkaSettings)
+		this.kafka = new Kafka({
+			brokers: ['127.0.0.1:9092'],
+			...kafkaSettings,
+		})
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds a default value for the `kafkaSettings.brokers` configuration required by KafkaJS.

## Steps to Test
1. `yarn test`

## Related Issues
Resolves #113