### PR TITLE
Update @tvkitchen/base-classes to 1.4.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Update `@tvkitchen/base-classes` to version `1.4.0-alpha.2`
 
 ## [0.2.1] - 2020-10-18
 ### Changed

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://tv.kitchen",
   "dependencies": {
-    "@tvkitchen/base-classes": "1.4.0-alpha.1",
+    "@tvkitchen/base-classes": "1.4.0-alpha.2",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.0",
     "@tvkitchen/base-interfaces": "4.0.0-alpha.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,10 +1128,10 @@
   dependencies:
     type-detect "4.0.8"
 
-"@tvkitchen/base-classes@1.4.0-alpha.1":
-  version "1.4.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.4.0-alpha.1.tgz#af55076cb06e24907707e3c5f59133b098f830a8"
-  integrity sha512-Ge0+3lEpKpBP8fXCgP4Prhie/JKj/xa/MYzOQSjF8tQNAzIUtj7dhrHjt5UWniJAk4f0iDqpPS7xNGCPSjNrTw==
+"@tvkitchen/base-classes@1.4.0-alpha.2":
+  version "1.4.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.4.0-alpha.2.tgz#8bf355433bd088d5a2fa07de00d25105dcdfcc9a"
+  integrity sha512-xH0PS08AObEG2ZxnOrAbMBAb8ReMm8dwTd8ZKK5OyNAU4tSQmx8pLx4JQQIkwckms37RJM4VOrw5Wvulh44ExA==
   dependencies:
     avsc "^5.4.21"
 


### PR DESCRIPTION
## Description
This PR updates the version of @tvkitchen/base-classes to 1.4.0-alpha.2

## Related Issues
Resolves #125 