### PR TITLE
Add Docker authentication to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 
 before_install:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker-compose -f services/kafka/docker-compose.yml up -d
 
 script:


### PR DESCRIPTION
## Description
This PR fixes an issue where CI would not run because of Docker rate limits.

## Related Issues
Resolves #132
