### PR TITLE
Set Kafka retention to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`
 - Update `@tvkitchen/base-interfaces` to version `4.0.0-alpha.4`
+- Specify Kafka topic data retention times to 30 seconds.
 
 ### Added
 - Appliances can now be added to a countertop without having sources for any given input.

--- a/src/classes/CountertopWorker.js
+++ b/src/classes/CountertopWorker.js
@@ -102,7 +102,12 @@ class CountertopWorker {
 			),
 		)
 		const outputTopicConfigs = outputTopics.map(
-			(topic) => ({ topic }),
+			(topic) => ({
+				topic,
+				configEntries: [
+					{ name: 'retention.ms', value: '30000' },
+				],
+			}),
 		)
 		await this.admin.createTopics({
 			waitForLeaders: true,


### PR DESCRIPTION
## Description
This PR changes the retention time in Kafka to 30 seconds from 7 days.  This should mean that TV Kitchen won't fill up hard drives simply by running.

## Related Issues
Resolves #133