### PR TITLE
Allow partial input topologies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The static `getInputTypes` and `getOutputTypes` Appliance methods are now provided the relevant settings values, allowing for dynamic types.
 
+### Fixed
+- Topologies with Appliances that only have a subset of their input satisfied will no longer break ([Issue #149](https://github.com/tvkitchen/countertop/issues/149)).
+
 ## [0.3.0] - 2021-05-13
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.1`.

--- a/src/classes/CountertopWorker.js
+++ b/src/classes/CountertopWorker.js
@@ -92,10 +92,18 @@ class CountertopWorker {
 		const inputTopics = this.appliance.constructor.getInputTypes(
 			this.appliance.settings,
 		).map(
-			(inputType) => getStreamTopic(
-				inputType,
-				this.stream.getTributaryMap().get(inputType),
-			),
+			(inputType) => {
+				const inputStream = this.stream.getTributaryMap().get(inputType)
+				if (inputStream) {
+					return getStreamTopic(
+						inputType,
+						inputStream,
+					)
+				}
+				return null
+			},
+		).filter(
+			(topic) => topic !== null,
 		)
 		const outputTopics = this.appliance.constructor.getOutputTypes(
 			this.appliance.settings,


### PR DESCRIPTION
This PR fixes a bug where topologies with appliances that only had a subset of inputs provided would error.

Resolves #149