### PR TITLE
Import base-constants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/src/types/DataType.ts
+++ b/src/types/DataType.ts
@@ -1,0 +1,7 @@
+export enum DataType {
+	StreamContainer = 'STREAM.CONTAINER',
+	TextAtom = 'TEXT.ATOM',
+	TextBlob = 'TEXT.BLOB',
+	TextWord = 'TEXT.WORD',
+	TextSentence = 'TEXT.SENTENCE',
+}

--- a/src/types/LogLevel.ts
+++ b/src/types/LogLevel.ts
@@ -1,0 +1,8 @@
+export enum LogLevel {
+	Fatal = 'fatal',
+	Error = 'error',
+	Warn = 'warn',
+	Info = 'info',
+	Debug = 'debug',
+	Trace = 'trace',
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export { DataType } from './DataType'
+export { LogLevel } from './LogLevel'


### PR DESCRIPTION
This PR imports the base-constants values from the [@tvkitchen/base-constants](https://github.com/tvkitchen/base/tree/main/packages/constants) package and rewrites them as TypeScript.

Related to #154
