### PR TITLE
Support multiple coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,11 @@ jobs:
         node-version: 16.x
     - run: yarn install
     - run: yarn build
-    - run: yarn test --coverage
+    - run: yarn test:js --coverage
     - uses: codecov/codecov-action@v2
+      with:
+        flags: -cF javascript
+    - run: yarn test:ts --coverage
+    - uses: codecov/codecov-action@v2
+      with:
+        flags: -cF typescript


### PR DESCRIPTION
This PR fixes our codecov analysis pipeline to process TS and JS separately, rather than ignoring JS.

Resolves #161