### PR TITLE
Use Ajv for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The `Payload` class is now part of the countertop.  This will replace the `@tvkitchen/base-classes` version of Payload.
 - TypeScript definitions related to `Payload`, `PayloadType`, and `PayloadParameters` are also exported.
+- New `ValidationError` error.
 
 ## [0.4.1] - 2022-06-08
 ### Changed

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/base-errors": "^1.0.0",
     "@tvkitchen/base-interfaces": "4.0.0-alpha.5",
+    "ajv": "^8.11.0",
+    "ajv-keywords": "^5.1.0",
     "kafkajs": "^1.12.0",
     "uuid": "^8.3.0"
   },

--- a/src/classes/__test__/Payload.unit.test.ts
+++ b/src/classes/__test__/Payload.unit.test.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from '../../errors'
 import { Payload } from '../Payload'
 
 describe('Payload', () => {
@@ -71,10 +72,10 @@ describe('Payload', () => {
 
 	describe('deserialize', () => {
 		it('should error when deserializing an empty serialized object', () => {
-			expect(() => Payload.deserialize('{}')).toThrow()
+			expect(() => Payload.deserialize('{}')).toThrow(ValidationError)
 		})
 		it('should error when deserializeing a partially populated serialized payload', () => {
-			expect(() => Payload.deserialize('{"type":"WHOOPS"}')).toThrow()
+			expect(() => Payload.deserialize('{"type":"WHOOPS"}')).toThrow(ValidationError)
 		})
 		it('should properly deserialize a serialized payload', () => {
 			const parameters = {
@@ -100,7 +101,7 @@ describe('Payload', () => {
 				position: 60000,
 			}
 			const serializedValues = JSON.stringify(parameters)
-			expect(() => Payload.deserialize(serializedValues)).toThrow()
+			expect(() => Payload.deserialize(serializedValues)).toThrow(ValidationError)
 		})
 	})
 })

--- a/src/classes/__test__/Payload.unit.test.ts
+++ b/src/classes/__test__/Payload.unit.test.ts
@@ -40,11 +40,16 @@ describe('Payload', () => {
 				duration: 1000,
 				position: 60000,
 			}
-			jest.setSystemTime(new Date('1592156234000'))
+			const firstTime = new Date(1592156234000)
+			const secondTime = new Date(1592156235000)
+			jest.useFakeTimers()
+			jest.setSystemTime(firstTime)
 			const firstPayload = new Payload(parameters)
-			jest.setSystemTime(new Date('1592156235000'))
+			jest.setSystemTime(secondTime)
 			const secondPayload = new Payload(parameters)
-			expect(firstPayload.createdAt).not.toEqual(secondPayload.createdAt)
+			jest.useRealTimers()
+			expect(firstPayload.createdAt).toEqual(firstTime.toISOString())
+			expect(secondPayload.createdAt).toEqual(secondTime.toISOString())
 		})
 	})
 

--- a/src/errors/ValidationError.ts
+++ b/src/errors/ValidationError.ts
@@ -1,0 +1,14 @@
+import type { ErrorObject } from 'ajv'
+
+export class ValidationError extends Error {
+	public errors?: ErrorObject[] | null
+
+	public constructor(
+		message?: string,
+		errors?: ErrorObject[] | null,
+	) {
+		super(message)
+		this.name = this.constructor.name
+		this.errors = errors
+	}
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './ValidationError'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export * from './errors'
 export * from './types'

--- a/src/tools/ajv.ts
+++ b/src/tools/ajv.ts
@@ -1,0 +1,5 @@
+import Ajv from 'ajv'
+import AjvKeywords from 'ajv-keywords'
+
+export const ajv = new Ajv()
+AjvKeywords(ajv, 'instanceof')

--- a/src/types/PayloadParameters.ts
+++ b/src/types/PayloadParameters.ts
@@ -1,3 +1,5 @@
+import { ajv } from '../tools/ajv'
+import type { JSONSchemaType } from 'ajv'
 import type { PayloadType } from './PayloadType'
 
 export interface PayloadParameters {
@@ -8,12 +10,40 @@ export interface PayloadParameters {
 	duration: number;
 	position: number;
 }
-export const isPayloadParameters = (value: unknown): value is PayloadParameters => (
-	value instanceof Object
-	&& (value as PayloadParameters).data instanceof Buffer
-	&& typeof (value as PayloadParameters).type === 'string'
-	&& typeof (value as PayloadParameters).createdAt === 'string'
-	&& typeof (value as PayloadParameters).origin === 'string'
-	&& typeof (value as PayloadParameters).duration === 'number'
-	&& typeof (value as PayloadParameters).position === 'number'
-)
+
+export const payloadParametersSchema: JSONSchemaType<PayloadParameters> = {
+	type: 'object',
+	properties: {
+		data: {
+			type: 'object',
+			required: [],
+			instanceof: 'Buffer',
+		},
+		type: {
+			type: 'string',
+		},
+		createdAt: {
+			type: 'string',
+			nullable: true,
+		},
+		origin: {
+			type: 'string',
+		},
+		duration: {
+			type: 'integer',
+		},
+		position: {
+			type: 'integer',
+		},
+	},
+	required: [
+		'data',
+		'type',
+		'origin',
+		'duration',
+		'position',
+	],
+	additionalProperties: false,
+}
+
+export const isPayloadParameters = ajv.compile(payloadParametersSchema)

--- a/src/types/__test__/PayloadParameters.unit.test.ts
+++ b/src/types/__test__/PayloadParameters.unit.test.ts
@@ -1,0 +1,103 @@
+import { isPayloadParameters } from '../PayloadParameters'
+
+describe('isPayloadParameters', () => {
+	it('should return true for valid payload parameters', () => {
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(true)
+	})
+	it('should return true with no createdAt parameter', () => {
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(true)
+	})
+	it('should return false for incomplete payload parameters', () => {
+		expect(isPayloadParameters({
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(false)
+	})
+	it('should return false for overly populated payload parameters', () => {
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+			notReallyUsed: 42,
+		})).toEqual(false)
+	})
+	it('should return false for incorrectly typed payload parameters', () => {
+		expect(isPayloadParameters({
+			data: 'this is not a buffer',
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(false)
+		expect(isPayloadParameters({
+			data: {
+				field: 'this is an object, but not a buffer.',
+			},
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(false)
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 42,
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(false)
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			createdAt: 0,
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: 60000,
+		})).toEqual(false)
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: 0,
+			duration: 1000,
+			position: 60000,
+		})).toEqual(false)
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: '1000',
+			position: 60000,
+		})).toEqual(false)
+		expect(isPayloadParameters({
+			data: Buffer.from('I ate all of the cheese'),
+			type: 'CONFESSION',
+			createdAt: '2020-02-02T03:04:05.000Z',
+			origin: '2020-02-02T03:04:01.000Z',
+			duration: 1000,
+			position: '60000',
+		})).toEqual(false)
+	})
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,13 @@ acorn@^8.7.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
+ajv-keywords@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1679,6 +1686,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-escapes@^4.2.1:
@@ -3858,6 +3875,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
@@ -4657,6 +4679,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR incorporates [Ajv](https://www.npmjs.com/package/ajv) into the Countertop in order to support more robust runtime validation.

This is particularly important because we are serializing / deserializing between json, and ajv is quite fast at that validation.  (Note that we will probably want to use Ajv to serialize and deserialize Payloads too instead of JSON.stringify, since it is in theory 10x faster)

In addition to incorporating Ajv this fixes a few bugs I found in the tests.

Resolves #166 