### PR TITLE
Prune obsolete streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Payload` class now supports serialization and deserialization to bytes / Buffer.
 - The `PayloadArray` class is now part of the countertop. It has a slightly modified API.
 
+### Fixed
+- Countertop topologies will no longer create redundant streams containing partially complete tributary sets when a more complete tributary superset is available for a given station.
+
 ## [0.4.1] - 2022-06-08
 ### Changed
 - Update `@tvkitchen/base-classes` to version `2.0.0-alpha.2` in order to support longer streams.

--- a/src/classes/CountertopStream.js
+++ b/src/classes/CountertopStream.js
@@ -93,6 +93,15 @@ class CountertopStream {
 		|| this.getTributaryArray().some((tributary) => tributary.includesStation(station))
 
 	/**
+	 * Checks if a given stream exists at any point within the stream.
+	 *
+	 * @param  {CountertopStream} stream The stream being searched for.
+	 * @return {Boolean}                   The result of the search.
+	 */
+	includesStream = (stream) => this.getTributaryArray().includes(stream)
+		|| this.getTributaryArray().some((tributary) => tributary.includesStream(stream))
+
+	/**
 	 * Get the output types produced by this stream.
 	 *
 	 * @return {String[]} The output types.

--- a/src/classes/CountertopTopology.js
+++ b/src/classes/CountertopTopology.js
@@ -7,6 +7,8 @@ import {
 	generateTributaryMaps,
 	getStreamOutputMap,
 	getSourceStations,
+	identifyObsoleteStreams,
+	pruneStreams,
 } from '../tools/utils/countertop'
 
 /**
@@ -89,11 +91,19 @@ class CountertopTopology {
 				// Remove any new streams that aren't long enough
 				.filter((stream) => stream.getLength() === extentionLength)
 		}
+		// Prune any past streams whose tributaries are explicit subsets of new streams
+		const obsoleteStreams = identifyObsoleteStreams(streams, nextStreams)
+		const prunedStreams = pruneStreams(streams, obsoleteStreams)
+		const prunedNextStreams = pruneStreams(nextStreams, obsoleteStreams)
+
 		// If there were any new streams, iterate again
-		if (nextStreams.length !== 0) {
-			return CountertopTopology.generateStreams(stations, streams.concat(nextStreams))
+		if (prunedNextStreams.length !== 0) {
+			return CountertopTopology.generateStreams(
+				stations,
+				prunedStreams.concat(prunedNextStreams),
+			)
 		}
-		return streams
+		return prunedStreams
 	}
 
 	/**

--- a/src/classes/__tests__/CountertopTopology.unit.test.js
+++ b/src/classes/__tests__/CountertopTopology.unit.test.js
@@ -79,6 +79,51 @@ describe('CountertopTopology #unit', () => {
 			const streams = CountertopTopology.generateStreams(stations)
 			expect(normalizeStreams(streams, stations)).toMatchSnapshot()
 		})
+		it('Should not generate redundant partial streams for stations with multiple inputs', () => {
+			const ApplianceA = generateMockAppliance({
+				inputTypes: [],
+				outputTypes: ['foo'],
+			})
+			const ApplianceB = generateMockAppliance({
+				inputTypes: ['foo'],
+				outputTypes: ['bar'],
+			})
+			const ApplianceC = generateMockAppliance({
+				inputTypes: ['foo', 'bar'],
+				outputTypes: ['baz'],
+			})
+			const stationA = new CountertopStation(ApplianceA)
+			const stationB = new CountertopStation(ApplianceB)
+			const stationC = new CountertopStation(ApplianceC)
+			const stations = [stationA, stationB, stationC]
+			const streams = CountertopTopology.generateStreams(stations)
+			expect(normalizeStreams(streams, stations)).toMatchSnapshot()
+		})
+		it('Should maintain complete toplogies after redundant partial streams are removed', () => {
+			const ApplianceA = generateMockAppliance({
+				inputTypes: [],
+				outputTypes: ['foo'],
+			})
+			const ApplianceB = generateMockAppliance({
+				inputTypes: ['foo'],
+				outputTypes: ['bar'],
+			})
+			const ApplianceC = generateMockAppliance({
+				inputTypes: ['foo', 'bar'],
+				outputTypes: ['baz'],
+			})
+			const ApplianceD = generateMockAppliance({
+				inputTypes: ['baz'],
+				outputTypes: ['bop'],
+			})
+			const stationA = new CountertopStation(ApplianceA)
+			const stationB = new CountertopStation(ApplianceB)
+			const stationC = new CountertopStation(ApplianceC)
+			const stationD = new CountertopStation(ApplianceD)
+			const stations = [stationA, stationB, stationC, stationD]
+			const streams = CountertopTopology.generateStreams(stations)
+			expect(normalizeStreams(streams, stations)).toMatchSnapshot()
+		})
 	})
 
 	describe('generateSourceStreams', () => {

--- a/src/classes/__tests__/__snapshots__/CountertopTopology.unit.test.js.snap
+++ b/src/classes/__tests__/__snapshots__/CountertopTopology.unit.test.js.snap
@@ -31,6 +31,120 @@ Array [
 ]
 `;
 
+exports[`CountertopTopology #unit generateStreams Should maintain complete toplogies after redundant partial streams are removed 1`] = `
+Array [
+  Object {
+    "mouth": 0,
+    "source": 0,
+    "tributaryMap": Map {},
+  },
+  Object {
+    "mouth": 1,
+    "source": 0,
+    "tributaryMap": Map {
+      "foo" => Object {
+        "mouth": 0,
+        "source": 0,
+        "tributaryMap": Map {},
+      },
+    },
+  },
+  Object {
+    "mouth": 2,
+    "source": 0,
+    "tributaryMap": Map {
+      "foo" => Object {
+        "mouth": 0,
+        "source": 0,
+        "tributaryMap": Map {},
+      },
+      "bar" => Object {
+        "mouth": 1,
+        "source": 0,
+        "tributaryMap": Map {
+          "foo" => Object {
+            "mouth": 0,
+            "source": 0,
+            "tributaryMap": Map {},
+          },
+        },
+      },
+    },
+  },
+  Object {
+    "mouth": 3,
+    "source": 0,
+    "tributaryMap": Map {
+      "baz" => Object {
+        "mouth": 2,
+        "source": 0,
+        "tributaryMap": Map {
+          "foo" => Object {
+            "mouth": 0,
+            "source": 0,
+            "tributaryMap": Map {},
+          },
+          "bar" => Object {
+            "mouth": 1,
+            "source": 0,
+            "tributaryMap": Map {
+              "foo" => Object {
+                "mouth": 0,
+                "source": 0,
+                "tributaryMap": Map {},
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`CountertopTopology #unit generateStreams Should not generate redundant partial streams for stations with multiple inputs 1`] = `
+Array [
+  Object {
+    "mouth": 0,
+    "source": 0,
+    "tributaryMap": Map {},
+  },
+  Object {
+    "mouth": 1,
+    "source": 0,
+    "tributaryMap": Map {
+      "foo" => Object {
+        "mouth": 0,
+        "source": 0,
+        "tributaryMap": Map {},
+      },
+    },
+  },
+  Object {
+    "mouth": 2,
+    "source": 0,
+    "tributaryMap": Map {
+      "foo" => Object {
+        "mouth": 0,
+        "source": 0,
+        "tributaryMap": Map {},
+      },
+      "bar" => Object {
+        "mouth": 1,
+        "source": 0,
+        "tributaryMap": Map {
+          "foo" => Object {
+            "mouth": 0,
+            "source": 0,
+            "tributaryMap": Map {},
+          },
+        },
+      },
+    },
+  },
+]
+`;
+
 exports[`CountertopTopology #unit generateStreams Should not generate streams for stations with no inputs 1`] = `
 Array [
   Object {


### PR DESCRIPTION
This PR fixes an issue where topologies might contain duplicate stations with partially overlapping input streams. 

Resolves #159